### PR TITLE
Fixes #11 - Incorrect archiveFileName for Windows GCC 9.3.1.11 archive

### DIFF
--- a/json/package_energia_optimized_index.json
+++ b/json/package_energia_optimized_index.json
@@ -448,7 +448,7 @@
               "url": "https://github.com/Andy4495/TI_Platform_Cores_For_Arduino/releases/download/v1.3.0/msp430-gcc-9.3.1.11_win64.zip", 
               "checksum": "SHA-256:1D087B7F19B9A69214E83C9671DCEB5B5D261287807C8E55CD523FFD57016F29", 
               "host": "i686-mingw32", 
-              "archiveFileName": "msp430-elf-gcc-9.3.1.11_win32.tar.bz2", 
+              "archiveFileName": "msp430-gcc-9.3.1.11_win64.zip", 
               "size": "114591102"
             }, 
             {


### PR DESCRIPTION
Updated the `archiveFileName` key in `package_energia_optimized_index.json` file to the correct filename.