### PR TITLE
Merge MSP432E Platform core 5.19.1 (Fixes #16 - Arduino Boards Manager compatibility)

### DIFF
--- a/json/package_energia_optimized_index.json
+++ b/json/package_energia_optimized_index.json
@@ -140,7 +140,7 @@
           "version": "5.19.1",
           "category": "Energia",
           "url": "https://github.com/Andy4495/TI_Platform_Cores_For_Arduino/raw/main/boards/msp432e-core-5.19.1.tar.bz2",
-          "archiveFileName": "msp432e-5.19.0.tar.bz2",
+          "archiveFileName": "msp432e-5.19.1.tar.bz2",
           "checksum": "SHA-256:f4d00731b1597aba846cac276cb61eadeba03c93d444dc00584406bb27a5bbbb",
           "size": "36088527",
           "boards": [


### PR DESCRIPTION
Updates the MSP432E core to be compatible with Arduino Boards Manager (fixes #16).
Also updates related tool: ino2cpp to version 1.0.7 and dslite to version 12.8. The dslite version update removes a dependency on the obsolete Python 2.